### PR TITLE
Skip de-arrayification if connecting to a MapGuide Open Source 4.0+ server

### DIFF
--- a/src/api/builders/mapagent.ts
+++ b/src/api/builders/mapagent.ts
@@ -5,6 +5,7 @@ import { RequestBuilder, ICreateRuntimeMapOptions, IQueryMapFeaturesOptions, IDe
 import { RuntimeMap } from '../contracts/runtime-map';
 import { QueryMapFeaturesResponse } from '../contracts/query';
 import { ResourceIdentifier, ResourceBase, SiteVersionResponse } from '../contracts/common';
+import { parseSiteVersion } from '../../utils/site-version';
 
 const MG_MAPAGENT_ERROR_CODE = 559;
 
@@ -39,9 +40,55 @@ export function serialize(data: any, uppercase: boolean = true): string {
  */
 export class MapAgentRequestBuilder extends RequestBuilder {
     private locale: string;
+    private cachedSiteVersion: SiteVersionResponse | null = null;
     constructor(agentUri: string, locale: string = DEFAULT_LOCALE) {
         super(agentUri);
         this.locale = locale;
+    }
+
+    private async getRawJson(url: string): Promise<any> {
+        const response = await fetch(url, {
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            } as any,
+            method: "GET"
+        });
+        if (isErrorResponse(response)) {
+            throw new MgError(response.statusText);
+        }
+        return await response.json();
+    }
+
+    private extractCleanResourceJson(json: any): any {
+        if (json?.ApplicationDefinition) {
+            return json.ApplicationDefinition;
+        }
+        if (json?.WebLayout) {
+            return json.WebLayout;
+        }
+        if (json?.MapDefinition) {
+            return json.MapDefinition;
+        }
+        if (json?.TileSetDefinition) {
+            return json.TileSetDefinition;
+        }
+        return json;
+    }
+
+    private async getCachedSiteVersion(): Promise<SiteVersionResponse> {
+        if (this.cachedSiteVersion) {
+            return this.cachedSiteVersion;
+        }
+        const sv = await this.getSiteVersion();
+        this.cachedSiteVersion = sv;
+        return sv;
+    }
+
+    private async canUseCleanResourceContent(): Promise<boolean> {
+        const sv = await this.getCachedSiteVersion();
+        const [major] = parseSiteVersion(sv.Version);
+        return major >= 4;
     }
 
     public async get<T>(url: string): Promise<T> {
@@ -141,14 +188,22 @@ export class MapAgentRequestBuilder extends RequestBuilder {
         }
     }
 
-    public getResource<T extends ResourceBase>(resourceId: ResourceIdentifier, args?: any): Promise<T> {
+    public async getResource<T extends ResourceBase>(resourceId: ResourceIdentifier, args?: any): Promise<T> {
         if (args != null) {
+            const isAppDef = typeof resourceId === "string" && /applicationdefinition$/i.test(resourceId.trim());
+            if (isAppDef && await this.canUseCleanResourceContent()) {
+                const p1 = { operation: "GETRESOURCECONTENT", resourceId: resourceId, version: "4.0.0", clean: 1 };
+                const url = this.stringifyGetUrl({ ...args, ...p1 });
+                const json = await this.getRawJson(url);
+                return this.extractCleanResourceJson(json) as T;
+            }
+
             const p1 = { operation: "GETRESOURCECONTENT", resourceId: resourceId };
             const url = this.stringifyGetUrl({ ...args, ...p1 });
-            return this.get<T>(url);
+            return await this.get<T>(url);
         } else {
             const url = this.stringifyGetUrl({ operation: "GETRESOURCE", resourceId: resourceId });
-            return this.get<T>(url);
+            return await this.get<T>(url);
         }
     }
 

--- a/src/api/builders/mapagent.ts
+++ b/src/api/builders/mapagent.ts
@@ -40,7 +40,7 @@ export function serialize(data: any, uppercase: boolean = true): string {
  */
 export class MapAgentRequestBuilder extends RequestBuilder {
     private locale: string;
-    private cachedSiteVersion: SiteVersionResponse | null = null;
+        private static siteVersionCache = new Map<string, Promise<SiteVersionResponse>>();
     constructor(agentUri: string, locale: string = DEFAULT_LOCALE) {
         super(agentUri);
         this.locale = locale;
@@ -76,17 +76,18 @@ export class MapAgentRequestBuilder extends RequestBuilder {
         return json;
     }
 
-    private async getCachedSiteVersion(): Promise<SiteVersionResponse> {
-        if (this.cachedSiteVersion) {
-            return this.cachedSiteVersion;
+        private extractCleanRuntimeMapJson(json: any): any {
+            if (json?.RuntimeMap) {
+                return json.RuntimeMap;
         }
-        const sv = await this.getSiteVersion();
-        this.cachedSiteVersion = sv;
-        return sv;
+            if (json?.Map) {
+                return json.Map;
+            }
+            return json;
     }
 
     private async canUseCleanResourceContent(): Promise<boolean> {
-        const sv = await this.getCachedSiteVersion();
+            const sv = await this.getSiteVersion();
         const [major] = parseSiteVersion(sv.Version);
         return major >= 4;
     }
@@ -208,9 +209,19 @@ export class MapAgentRequestBuilder extends RequestBuilder {
     }
 
     public getSiteVersion(): Promise<SiteVersionResponse> {
-        const p1 = { operation: "GETSITEVERSION", version: "1.0.0", username: "Anonymous" };
-        const url = this.stringifyGetUrl({ ...p1 });
-        return this.get<SiteVersionResponse>(url);
+            const cached = MapAgentRequestBuilder.siteVersionCache.get(this.agentUri);
+            if (cached) {
+                return cached;
+            }
+
+            const p1 = { operation: "GETSITEVERSION", version: "1.0.0", username: "Anonymous" };
+            const url = this.stringifyGetUrl({ ...p1 });
+            const pending = this.get<SiteVersionResponse>(url).catch((error) => {
+                MapAgentRequestBuilder.siteVersionCache.delete(this.agentUri);
+                throw error;
+            });
+            MapAgentRequestBuilder.siteVersionCache.set(this.agentUri, pending);
+            return pending;
     }
 
     public createRuntimeMap(options: ICreateRuntimeMapOptions): Promise<RuntimeMap> {
@@ -219,10 +230,11 @@ export class MapAgentRequestBuilder extends RequestBuilder {
         return this.get<RuntimeMap>(url);
     }
 
-    public createRuntimeMap_v4(options: ICreateRuntimeMapOptions): Promise<RuntimeMap> {
-        const p1 = { operation: "CREATERUNTIMEMAP", version: "4.0.0" };
+    public async createRuntimeMap_v4(options: ICreateRuntimeMapOptions): Promise<RuntimeMap> {
+        const p1 = { operation: "CREATERUNTIMEMAP", version: "4.0.0", clean: 1 };
         const url = this.stringifyGetUrl({ ...options, ...p1 });
-        return this.get<RuntimeMap>(url);
+        const json = await this.getRawJson(url);
+        return this.extractCleanRuntimeMapJson(json) as RuntimeMap;
     }
 
     public queryMapFeatures(options: IQueryMapFeaturesOptions): Promise<QueryMapFeaturesResponse> {
@@ -241,10 +253,11 @@ export class MapAgentRequestBuilder extends RequestBuilder {
         return this.get<RuntimeMap>(url);
     }
 
-    public describeRuntimeMap_v4(options: IDescribeRuntimeMapOptions): Promise<RuntimeMap> {
-        const p1 = { operation: "DESCRIBERUNTIMEMAP", version: "4.0.0" };
+    public async describeRuntimeMap_v4(options: IDescribeRuntimeMapOptions): Promise<RuntimeMap> {
+        const p1 = { operation: "DESCRIBERUNTIMEMAP", version: "4.0.0", clean: 1 };
         const url = this.stringifyGetUrl({ ...options, ...p1 });
-        return this.get<RuntimeMap>(url);
+        const json = await this.getRawJson(url);
+        return this.extractCleanRuntimeMapJson(json) as RuntimeMap;
     }
 
     public getTileTemplateUrl(resourceId: string, groupName: string, xPlaceholder: string, yPlaceholder: string, zPlaceholder: string, isXYZ: boolean): string {

--- a/src/api/registry/command-spec.ts
+++ b/src/api/registry/command-spec.ts
@@ -19,7 +19,8 @@ function isCommandSpec(cmd: ICommandSpec | IUnknownCommandSpec): cmd is ICommand
 }
 
 export function isUIWidget(widget: any): widget is UIWidget {
-    return widget.WidgetType === "UiWidgetType";
+    return widget.WidgetType === "UiWidgetType"
+        || widget["@xsi:type"] === "UiWidgetType";
 }
 
 /**
@@ -189,7 +190,7 @@ function convertWidget(widget: UIWidget, locale: string, noToolbarLabels: boolea
  * @returns 
  */
 export function convertFlexLayoutUIItems(isStateless: boolean, items: ContainerItem[], widgetsByKey: Dictionary<Widget>, locale: string, noToolbarLabels = false): (IFlyoutSpec | ISeparatorSpec | IUnknownCommandSpec | ICommandSpec)[] {
-    const converted = items.map(item => {
+    const converted = (items || []).map(item => {
         switch (item.Function) {
             case "Widget":
                 {

--- a/test-data/init_appdef_clean.ts
+++ b/test-data/init_appdef_clean.ts
@@ -1,0 +1,1681 @@
+export default {
+  "ApplicationDefinition": {
+    "@xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+    "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    "@xsi:noNamespaceSchemaLocation": "ApplicationDefinition-1.0.0.xsd",
+    "Extension": {
+      "OpenStreetMapScript": "http://www.openstreetmap.org/openlayers/OpenStreetMap.js",
+      "StadiaMapsKey": "d3d5b6ec-2786-453e-8767-23a2fc938c84",
+      "StamenScript": "http://maps.stamen.com/js/tile.stamen.js?v1.3.0"
+    },
+    "MapSet": {
+      "MapGroup": [
+        {
+          "@id": "Sheboygan",
+          "Map": [
+            {
+              "Extension": {
+                "MouseCoordinatesFormat": "Lng: {x} {units}, Lat: {y} {units}",
+                "ResourceId": "Library://Samples/Sheboygan/Maps/Sheboygan.MapDefinition"
+              },
+              "SingleTile": "True",
+              "Type": "MapGuide"
+            }
+          ]
+        },
+        {
+          "@id": "Redding",
+          "Map": [
+            {
+              "Extension": {
+                "Options": {
+                  "isBaseLayer": "false",
+                  "projection": "EPSG:900913",
+                  "useOverlay": "true"
+                },
+                "ResourceId": "Library://Redding/Maps/Redding.MapDefinition"
+              },
+              "SingleTile": "True",
+              "Type": "MapGuide"
+            },
+            {
+              "Extension": {
+                "Options": {
+                  "name": "Stamen (Toner)",
+                  "type": "toner"
+                }
+              },
+              "SingleTile": "true",
+              "Type": "Stamen"
+            },
+            {
+              "Extension": {
+                "Options": {
+                  "name": "Open Street Map",
+                  "type": "Mapnik"
+                }
+              },
+              "SingleTile": "true",
+              "Type": "OpenStreetMap"
+            }
+          ]
+        },
+        {
+          "@id": "Melbourne",
+          "Map": [
+            {
+              "Extension": {
+                "MouseCoordinatesFormat": "Easting: {x} {units}, Northing: {y} {units}",
+                "Options": {
+                  "isBaseLayer": "false",
+                  "projection": "EPSG:900913",
+                  "useOverlay": "true"
+                },
+                "ResourceId": "Library://Samples/Melbourne/Maps/Melbourne.MapDefinition"
+              },
+              "SingleTile": "True",
+              "Type": "MapGuide"
+            },
+            {
+              "Extension": {
+                "Options": {
+                  "name": "Stamen (Toner)",
+                  "type": "toner"
+                }
+              },
+              "SingleTile": "true",
+              "Type": "Stamen"
+            },
+            {
+              "Extension": {
+                "Options": {
+                  "name": "Open Street Map",
+                  "type": "Mapnik"
+                }
+              },
+              "SingleTile": "true",
+              "Type": "OpenStreetMap"
+            }
+          ]
+        }
+      ]
+    },
+    "TemplateUrl": "fusion/templates/mapguide/slate/index.html",
+    "Title": "Slate",
+    "WidgetSet": [
+      {
+        "Container": [
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Print"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "QuickPlot"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "RefreshMap"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Maptip"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Select"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "SelectRadius"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "SelectPolygon"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ClearSelection"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "tbBuffer"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Measure"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "FeatureInfo"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Query"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Theme"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Redline"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ViewOptions"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "About"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Help"
+              }
+            ],
+            "Name": "Toolbar",
+            "Position": "top",
+            "Type": "Toolbar"
+          },
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Select"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "WmsQuery"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Pan"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Zoom"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ZoomIn"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ZoomOut"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "InitialMapView"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ZoomToSelection"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "PreviousView"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "NextView"
+              }
+            ],
+            "Name": "ToolbarSecondary",
+            "Position": "top",
+            "Type": "Toolbar"
+          },
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertSelect"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "WmsQuery"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertPan"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertZoom"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertZoomIn"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertZoomOut"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertInitialMapView"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertZoomToSelection"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertPreviousView"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "vertNextView"
+              }
+            ],
+            "Name": "ToolbarVertical",
+            "Position": "left",
+            "Type": "Toolbar"
+          },
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "MapMenu"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "BasemapSwitcher"
+              },
+              {
+                "@xsi:type": "FlyoutItemType",
+                "Function": "Flyout",
+                "Item": [
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "showOverview"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "showTaskPane"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "showLegend"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "showSelectionPanel"
+                  }
+                ],
+                "Label": "View"
+              },
+              {
+                "@xsi:type": "FlyoutItemType",
+                "Function": "Flyout",
+                "Item": [
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "ViewerApiExample"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "DrawingExample"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "SubscriberExample"
+                  }
+                ],
+                "Label": "Viewer API"
+              },
+              {
+                "@xsi:type": "FlyoutItemType",
+                "Function": "Flyout",
+                "Item": [
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "AddExternalLayers"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "ShareLink"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "Geolocation"
+                  },
+                  {
+                    "@xsi:type": "WidgetItemType",
+                    "Function": "Widget",
+                    "Widget": "CoordinateTracker"
+                  }
+                ],
+                "Label": "Tools"
+              }
+            ],
+            "Name": "FileMenu",
+            "Position": "top",
+            "Type": "Toolbar"
+          },
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "statusCoordinates"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "statusSelection"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "EditableScale"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "statusViewSize"
+              }
+            ],
+            "Name": "Statusbar",
+            "Position": "bottom",
+            "Type": "Splitterbar"
+          },
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "RefreshMap"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Pan"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Zoom"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ZoomIn"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ZoomOut"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "FlyoutItemType",
+                "Function": "Flyout",
+                "Label": "Zoom"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Select"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ClearSelection"
+              },
+              {
+                "@xsi:type": "FlyoutItemType",
+                "Function": "Flyout",
+                "Label": "Select More"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "tbBuffer"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Measure"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "FeatureInfo"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Query"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Theme"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Redline"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "ViewOptions"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Help"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "About"
+              }
+            ],
+            "Name": "MapContextMenu",
+            "Position": "top",
+            "Type": "ContextMenu"
+          },
+          {
+            "@xsi:type": "UiItemContainerType",
+            "Extension": null,
+            "Item": [
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Measure"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "tbBuffer"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "FeatureInfo"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Query"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Theme"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "Redline"
+              },
+              {
+                "@xsi:type": "SeparatorItemType",
+                "Function": "Separator"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "AddExternalLayers"
+              },
+              {
+                "@xsi:type": "WidgetItemType",
+                "Function": "Widget",
+                "Widget": "CoordinateTracker"
+              }
+            ],
+            "Name": "TaskMenu",
+            "Position": "top",
+            "Type": "ContextMenu"
+          }
+        ],
+        "MapWidget": {
+          "Extension": {
+            "MenuContainer": "MapContextMenu"
+          },
+          "MapId": "Sheboygan",
+          "Name": "Map",
+          "Type": "Map"
+        },
+        "Widget": [
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AboutURL": "widgets/About/About.html"
+            },
+            "ImageClass": "about",
+            "ImageUrl": "images/icons.png",
+            "Label": "About",
+            "Location": null,
+            "Name": "About",
+            "StatusText": null,
+            "Tooltip": "Click to show information about this application",
+            "Type": "About"
+          },
+          {
+            "Extension": {
+
+            },
+            "Location": null,
+            "Name": "ActivityIndicator",
+            "Type": "ActivityIndicator"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "options",
+            "ImageUrl": "images/icons.png",
+            "Label": "External Providers",
+            "Location": null,
+            "Name": "BasemapSwitcher",
+            "StatusText": null,
+            "Tooltip": "Click to change the basemap",
+            "Type": "BasemapSwitcher"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Target": "TaskPane"
+            },
+            "ImageClass": "buffer",
+            "ImageUrl": "images/icons.png",
+            "Label": "Buffer",
+            "Location": null,
+            "Name": "BufferPanel",
+            "StatusText": null,
+            "Tooltip": "Click to create a buffer",
+            "Type": "BufferPanel"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "select-centre",
+            "ImageUrl": "images/icons.png",
+            "Label": "Center selection",
+            "Location": null,
+            "Name": "CenterSelection",
+            "StatusText": null,
+            "Tooltip": "Click to center the map on the current selection",
+            "Type": "CenterSelection"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "select-clear",
+            "ImageUrl": "images/icons.png",
+            "Label": "Clear Selection",
+            "Location": null,
+            "Name": "ClearSelection",
+            "StatusText": null,
+            "Tooltip": "Click to clear the current selection",
+            "Type": "ClearSelection"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Color picker",
+            "Location": null,
+            "Name": "ColorPicker",
+            "StatusText": null,
+            "Tooltip": "Use this tool to select a color",
+            "Type": "ColorPicker"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Projection": [
+                "EPSG:4326",
+                "EPSG:3857"
+              ],
+              "Target": "TaskPane"
+            },
+            "ImageClass": "coordinate-tracker",
+            "ImageUrl": "images/icons.png",
+            "Label": "Coordinate Tracker",
+            "Location": null,
+            "Name": "CoordinateTracker",
+            "StatusText": null,
+            "Tooltip": "Click to view mouse coordinates in various projections",
+            "Type": "CoordinateTracker"
+          },
+          {
+            "Extension": {
+              "Precision": "4"
+            },
+            "Location": null,
+            "Name": "EditableScale",
+            "Type": "EditableScale"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Target": "TaskPane"
+            },
+            "ImageClass": "feature-info",
+            "ImageUrl": "images/icons.png",
+            "Label": "Feature Info",
+            "Location": null,
+            "Name": "FeatureInfo",
+            "StatusText": null,
+            "Tooltip": "Click to display selected feature info",
+            "Type": "FeatureInfo"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "EnableHighAccuracy": "false",
+              "MaximumAge": "0",
+              "Timeout": "5000"
+            },
+            "ImageClass": "geolocation",
+            "ImageUrl": "images/icons.png",
+            "Label": "My Location",
+            "Location": null,
+            "Name": "Geolocation",
+            "StatusText": null,
+            "Tooltip": "Click to zoom to your current geographic location",
+            "Type": "Geolocation"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "DirectionLength": "22",
+              "ShowDirection": "true",
+              "SymbolLayerName": "GoogleStreetViewerSymbolLayer",
+              "Target": "TaskPane"
+            },
+            "ImageClass": null,
+            "ImageUrl": "../../../widgets/GoogleStreetViewer/GoogleStreetView.png",
+            "Label": "Google StreetView",
+            "Location": null,
+            "Name": "GoogleStreetViewer",
+            "StatusText": null,
+            "Tooltip": "Click to show Google StreetView",
+            "Type": "GoogleStreetViewer"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Target": "HelpWindow",
+              "Url": "widgets/Help/Help.html"
+            },
+            "ImageClass": "help",
+            "ImageUrl": "images/icons.png",
+            "Label": "Help",
+            "Location": null,
+            "Name": "Help",
+            "StatusText": null,
+            "Tooltip": "Click to get help",
+            "Type": "Help"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "ViewType": "initial"
+            },
+            "ImageClass": "zoom-full",
+            "ImageUrl": "images/icons.png",
+            "Label": "Zoom Extents",
+            "Location": null,
+            "Name": "InitialMapView",
+            "StatusText": null,
+            "Tooltip": "Click to zoom to the full map extents",
+            "Type": "InitialMapView"
+          },
+          {
+            "Extension": {
+              "DisabledLayerIcon": "images/icons/legend-layer.png",
+              "GroupInfoIcon": "images/icons/tree_group_info.png",
+              "HideInvisibleLayers": "true",
+              "LayerDWFIcon": "images/icons/legend-DWF.png",
+              "LayerInfoIcon": "images/icons/tree_layer_info.png",
+              "LayerRasterIcon": "images/icons/legend-raster.png",
+              "LayerThemeIcon": "images/icons/legend-theme.png",
+              "RootFolderIcon": "images/icons/legend-map.png",
+              "ShowMapFolder": "false",
+              "ShowRootFolder": "false"
+            },
+            "Location": null,
+            "Name": "Legend",
+            "Type": "Legend"
+          },
+          {
+            "Extension": null,
+            "Location": null,
+            "Name": "LinkToView",
+            "Type": "LinkToView"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+
+            },
+            "ImageClass": "legend-map",
+            "ImageUrl": "images/icons.png",
+            "Label": "Maps",
+            "Location": null,
+            "Name": "MapMenu",
+            "StatusText": null,
+            "Tooltip": "Choose a map theme",
+            "Type": "MapMenu"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Delay": "350",
+              "Target": "MaptipWindow",
+              "Tolerance": "2",
+              "WinFeatures": "menubar=no,location=no,resizable=no,status=no"
+            },
+            "ImageClass": "maptip",
+            "ImageUrl": "images/icons.png",
+            "Label": "Maptip",
+            "Location": null,
+            "Name": "Maptip",
+            "StatusText": null,
+            "Tooltip": "Click to Enable/Disable get information about features from Server",
+            "Type": "Maptip"
+          },
+          {
+            "Extension": null,
+            "Location": null,
+            "Name": "Navigator",
+            "Type": "Navigator"
+          },
+          {
+            "Extension": {
+              "MaxRatio": "128",
+              "MinRatio": "32"
+            },
+            "Location": null,
+            "Name": "OverviewMap",
+            "Type": "OverviewMap"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "pan",
+            "ImageUrl": "images/icons.png",
+            "Label": "Pan",
+            "Location": null,
+            "Name": "Pan",
+            "StatusText": null,
+            "Tooltip": "Click and drag to pan the map",
+            "Type": "Pan"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "none",
+              "Percentage": "75"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": null,
+            "Location": null,
+            "Name": "PanOnClick",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "PanOnClick"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "QueryActiveLayer": "false",
+              "SelectionType": "INTERSECTS",
+              "Tolerance": "3"
+            },
+            "ImageClass": "pan",
+            "ImageUrl": "images/icons.png",
+            "Label": "Pan query",
+            "Location": null,
+            "Name": "PanQuery",
+            "StatusText": null,
+            "Tooltip": "Drag the mouse to pan, click to query",
+            "Type": "PanQuery"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "ShowLegend": "false",
+              "ShowNorthArrow": "false",
+              "ShowPrintUI": "true",
+              "ShowTitle": "false"
+            },
+            "ImageClass": "file-print",
+            "ImageUrl": "images/icons.png",
+            "Label": "Print",
+            "Location": null,
+            "Name": "Print",
+            "StatusText": null,
+            "Tooltip": "Print the current map view",
+            "Type": "Print"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Target": "TaskPane"
+            },
+            "ImageClass": "query",
+            "ImageUrl": "images/icons.png",
+            "Label": "Query",
+            "Location": null,
+            "Name": "Query",
+            "StatusText": null,
+            "Tooltip": "Click to execute a custom query",
+            "Type": "Query"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AllowDisclaimerToggle": "true",
+              "DefaultDpi": "96",
+              "DefaultMargin": "25.4,12.7,12.7,12.7",
+              "Disclaimer": "The materials available at this web site are for informational purposes only and do not constitute a legal document.",
+              "RememberPlotOptions": "false",
+              "ShowCoordinateLabels": "true",
+              "ShowCoordinates": "false",
+              "ShowLegalDisclaimer": "true",
+              "ShowLegend": "false",
+              "ShowNorthArrow": "false",
+              "ShowScaleBar": "false",
+              "ShowSubTitle": "true",
+              "Target": "TaskPane"
+            },
+            "ImageClass": null,
+            "ImageUrl": "images/icons/print.png",
+            "Label": "Quick Plot",
+            "Location": null,
+            "Name": "QuickPlot",
+            "StatusText": null,
+            "Tooltip": "Click to create a plot quickly",
+            "Type": "QuickPlot"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AutoCreateOnStartup": "true",
+              "AutogenerateLayerNames": "true",
+              "RedlineGeometryFormat": "7",
+              "StylizationType": "basic",
+              "Target": "TaskPane",
+              "UseMapMessage": "true"
+            },
+            "ImageClass": "redline",
+            "ImageUrl": "images/icons.png",
+            "Label": "Redline",
+            "Location": null,
+            "Name": "Redline",
+            "StatusText": null,
+            "Tooltip": "Click to draw redline features",
+            "Type": "Redline"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "view-refresh",
+            "ImageUrl": "images/icons.png",
+            "Label": "Refresh",
+            "Location": null,
+            "Name": "RefreshMap",
+            "StatusText": null,
+            "Tooltip": "Click to redraw the map",
+            "Type": "RefreshMap"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Format": "png"
+            },
+            "ImageClass": "file-save",
+            "ImageUrl": "images/icons.png",
+            "Label": "Save map",
+            "Location": null,
+            "Name": "SaveMap",
+            "StatusText": null,
+            "Tooltip": "Click to save the map as an image",
+            "Type": "SaveMap"
+          },
+          {
+            "Extension": {
+              "AbbreviateLabel": "true",
+              "DisplaySystem": "metric",
+              "Divisions": "2",
+              "MaxWidth": "200",
+              "MinWidth": "100",
+              "ShowMinorMeasures": "true",
+              "SingleLine": "false",
+              "Style": "thin",
+              "SubDivisions": "2"
+            },
+            "Location": null,
+            "Name": "Scalebar",
+            "Type": "Scalebar"
+          },
+          {
+            "Extension": {
+              "BottomInUnits": "m",
+              "BottomOutUnits": "km",
+              "MaxWidth": "300",
+              "TopInUnits": "ft",
+              "TopOutUnits": "mi"
+            },
+            "Location": null,
+            "Name": "ScalebarDual",
+            "Type": "ScalebarDual"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "QueryActiveLayer": "false",
+              "SelectionType": "INTERSECTS",
+              "Tolerance": "3"
+            },
+            "ImageClass": "select",
+            "ImageUrl": "images/icons.png",
+            "Label": "Select",
+            "Location": null,
+            "Name": "Select",
+            "StatusText": null,
+            "Tooltip": "Click to select features",
+            "Type": "Select"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "select",
+            "ImageUrl": "images/icons.png",
+            "Label": "WMS Query",
+            "Location": null,
+            "Name": "WmsQuery",
+            "StatusText": null,
+            "Tooltip": "Click to query for features in WMS layers at the point you click",
+            "Type": "WmsQuery"
+          },
+          {
+            "Extension": {
+              "ResultsPerPage": "0",
+              "SelectionRenderer": "Fusion.Widget.SelectionPanel.SelectionRendererDefault"
+            },
+            "Location": null,
+            "Name": "SelectionPanel",
+            "Type": "SelectionPanel"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "SelectionType": "INTERSECTS",
+              "Tolerance": "3"
+            },
+            "ImageClass": "select-polygon",
+            "ImageUrl": "images/icons.png",
+            "Label": "Select Polygon",
+            "Location": null,
+            "Name": "SelectPolygon",
+            "StatusText": null,
+            "Tooltip": "Draw a polygon to perform a selection",
+            "Type": "SelectPolygon"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "DefaultRadius": "20",
+              "RadiusTooltipType": "dynamic",
+              "SelectionType": "INTERSECTS",
+              "Tolerance": "3"
+            },
+            "ImageClass": "select-radius",
+            "ImageUrl": "images/icons.png",
+            "Label": "Select Radius",
+            "Location": null,
+            "Name": "SelectRadius",
+            "StatusText": null,
+            "Tooltip": "Click to select within a radius",
+            "Type": "SelectRadius"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "RadiusName": "SelectRadius"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Select radius value",
+            "Location": null,
+            "Name": "SelectRadiusValue",
+            "StatusText": null,
+            "Tooltip": "enter the radius for the Select by Radius tool",
+            "Type": "SelectRadiusValue"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "DisableIfSelectionEmpty": "true",
+              "OmitInvisibleLayers": "false",
+              "Target": "TaskPane"
+            },
+            "ImageClass": "select-features",
+            "ImageUrl": "images/icons.png",
+            "Label": "Select within",
+            "Location": null,
+            "Name": "SelectWithin",
+            "StatusText": null,
+            "Tooltip": "Click to select features within this selection",
+            "Type": "SelectWithin"
+          },
+          {
+            "Extension": {
+              "MenuContainer": "TaskMenu"
+            },
+            "Location": null,
+            "Name": "TaskPane",
+            "Type": "TaskPane"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Target": "TaskPane"
+            },
+            "ImageClass": "theme",
+            "ImageUrl": "images/icons.png",
+            "Label": "Theme",
+            "Location": null,
+            "Name": "Theme",
+            "StatusText": null,
+            "Tooltip": "Click to create a themed layer",
+            "Type": "Theme"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+
+            },
+            "ImageClass": "options",
+            "ImageUrl": "images/icons.png",
+            "Label": "Options",
+            "Location": null,
+            "Name": "ViewOptions",
+            "StatusText": null,
+            "Tooltip": "Click to change the units displayed",
+            "Type": "ViewOptions"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "in",
+              "Factor": "2",
+              "Tolerance": "5"
+            },
+            "ImageClass": "zoom-in",
+            "ImageUrl": "images/icons.png",
+            "Label": "Zoom Rectangle",
+            "Location": null,
+            "Name": "Zoom",
+            "StatusText": "Click or click and drag on the map to zoom in",
+            "Tooltip": "Click or click and drag on the map to zoom in",
+            "Type": "Zoom"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "MaximumZoomDimension": "-1",
+              "ZoomFactor": "2"
+            },
+            "ImageClass": "select-zoom",
+            "ImageUrl": "images/icons.png",
+            "Label": "Zoom Selection",
+            "Location": null,
+            "Name": "ZoomToSelection",
+            "StatusText": null,
+            "Tooltip": "Click to zoom to the selection",
+            "Type": "ZoomToSelection"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Factor": "2"
+            },
+            "ImageClass": "zoom-in-fixed",
+            "ImageUrl": "images/icons.png",
+            "Label": "Zoom In",
+            "Location": null,
+            "Name": "ZoomIn",
+            "StatusText": "Zoom in by a preset increment",
+            "Tooltip": "Zoom in by a preset increment",
+            "Type": "ZoomOnClick"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Factor": "0.5"
+            },
+            "ImageClass": "zoom-out-fixed",
+            "ImageUrl": "images/icons.png",
+            "Label": "Zoom Out",
+            "Location": null,
+            "Name": "ZoomOut",
+            "StatusText": "Zoom out by a preset increment",
+            "Tooltip": "Zoom out by a preset increment",
+            "Type": "ZoomOnClick"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "previous"
+            },
+            "ImageClass": "view-back",
+            "ImageUrl": "images/icons.png",
+            "Label": "Previous",
+            "Location": null,
+            "Name": "PreviousView",
+            "StatusText": "Go to previous view",
+            "Tooltip": "Go to previous view",
+            "Type": "ExtentHistory"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "next"
+            },
+            "ImageClass": "view-forward",
+            "ImageUrl": "images/icons.png",
+            "Label": "Next",
+            "Location": null,
+            "Name": "NextView",
+            "StatusText": "Go to next view",
+            "Tooltip": "Go to next view",
+            "Type": "ExtentHistory"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Target": "TaskPane"
+            },
+            "ImageClass": "buffer",
+            "ImageUrl": "images/icons.png",
+            "Label": "Buffer",
+            "Location": null,
+            "Name": "tbBuffer",
+            "StatusText": "Create buffers around the selected features",
+            "Tooltip": "Measure distances and areas on the map",
+            "Type": "BufferPanel"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AreaPrecision": "0",
+              "DistancePrecision": "0",
+              "MeasureTooltipContainer": "MeasureResult",
+              "MeasureTooltipType": "dynamic",
+              "Target": "TaskPane",
+              "Type": "both",
+              "Units": "meters"
+            },
+            "ImageClass": "measure",
+            "ImageUrl": "images/icons.png",
+            "Label": "Measure",
+            "Location": null,
+            "Name": "Measure",
+            "StatusText": "Measure distances and areas on the map",
+            "Tooltip": "Measure",
+            "Type": "Measure"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Script": "showOverviewMap()"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Show Overview",
+            "Location": null,
+            "Name": "showOverview",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeScript"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Script": "showTaskPane()"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Show Task Pane",
+            "Location": null,
+            "Name": "showTaskPane",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeScript"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Script": "showLegend()"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Show Legend",
+            "Location": null,
+            "Name": "showLegend",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeScript"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Script": "showSelectionPanel()"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Show Selection Panel",
+            "Location": null,
+            "Name": "showSelectionPanel",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeScript"
+          },
+          {
+            "Extension": {
+              "EmptyText": "&amp;nbsp;",
+              "Precision": "4",
+              "Template": "X: {x} {units}, Y: {y} {units}",
+              "Units": "dd"
+            },
+            "Location": null,
+            "Name": "statusCoordinates",
+            "Type": "CursorPosition"
+          },
+          {
+            "Extension": {
+              "EmptyText": "No selection",
+              "Template": "{0} feature(s) selected on {1} layer(s)"
+            },
+            "Location": null,
+            "Name": "statusSelection",
+            "Type": "SelectionInfo"
+          },
+          {
+            "Extension": {
+              "Precision": "2",
+              "Template": "{w} x {h} ({units})",
+              "Units": "Meters"
+            },
+            "Location": null,
+            "Name": "statusViewSize",
+            "Type": "ViewSize"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Factor": "2"
+            },
+            "ImageClass": "zoom-in-fixed",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertZoomIn",
+            "StatusText": "Zoom in by a preset increment",
+            "Tooltip": "Zoom in by a preset increment",
+            "Type": "ZoomOnClick"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Factor": "0.5"
+            },
+            "ImageClass": "zoom-out-fixed",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertZoomOut",
+            "StatusText": "Zoom out by a preset increment",
+            "Tooltip": "Zoom out by a preset increment",
+            "Type": "ZoomOnClick"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "previous"
+            },
+            "ImageClass": "view-back",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertPreviousView",
+            "StatusText": "Go to previous view",
+            "Tooltip": "Go to previous view",
+            "Type": "ExtentHistory"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "next"
+            },
+            "ImageClass": "view-forward",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertNextView",
+            "StatusText": "Go to next view",
+            "Tooltip": "Go to next view",
+            "Type": "ExtentHistory"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "QueryActiveLayer": "false",
+              "SelectionType": "INTERSECTS",
+              "Tolerance": "3"
+            },
+            "ImageClass": "select",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertSelect",
+            "StatusText": null,
+            "Tooltip": "Click to select features",
+            "Type": "Select"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": null,
+            "ImageClass": "pan",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertPan",
+            "StatusText": null,
+            "Tooltip": "Click and drag to pan the map",
+            "Type": "Pan"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "Direction": "in",
+              "Factor": "2",
+              "Tolerance": "5"
+            },
+            "ImageClass": "zoom-in",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertZoom",
+            "StatusText": "Click or click and drag on the map to zoom in",
+            "Tooltip": "Click or click and drag on the map to zoom in",
+            "Type": "Zoom"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "ViewType": "initial"
+            },
+            "ImageClass": "zoom-full",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertInitialMapView",
+            "StatusText": null,
+            "Tooltip": "Click to zoom to the full map extents",
+            "Type": "InitialMapView"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "MaximumZoomDimension": "-1",
+              "ZoomFactor": "2"
+            },
+            "ImageClass": "select-zoom",
+            "ImageUrl": "images/icons.png",
+            "Label": null,
+            "Location": null,
+            "Name": "vertZoomToSelection",
+            "StatusText": null,
+            "Tooltip": "Click to zoom to the selection",
+            "Type": "ZoomToSelection"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AdditionalParameter": null,
+              "DisableIfSelectionEmpty": "false",
+              "Target": "TaskPane",
+              "Url": "component://AddManageLayers"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Manage External Layers",
+            "Location": null,
+            "Name": "AddExternalLayers",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeURL"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AdditionalParameter": null,
+              "DisableIfSelectionEmpty": "false",
+              "Target": "InvokeUrlWindow",
+              "Url": "component://ShareLinkToView"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Share Link to View",
+            "Location": null,
+            "Name": "ShareLink",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeURL"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AdditionalParameter": null,
+              "DisableIfSelectionEmpty": "false",
+              "Target": "TaskPane",
+              "Url": "examples/taskpane/viewerapi.html"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Viewer API Example",
+            "Location": null,
+            "Name": "ViewerApiExample",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeURL"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AdditionalParameter": null,
+              "DisableIfSelectionEmpty": "false",
+              "Target": "TaskPane",
+              "Url": "examples/taskpane/drawing.html"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Drawing Example",
+            "Location": null,
+            "Name": "DrawingExample",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeURL"
+          },
+          {
+            "@xsi:type": "UiWidgetType",
+            "Disabled": false,
+            "Extension": {
+              "AdditionalParameter": null,
+              "DisableIfSelectionEmpty": "false",
+              "Target": "TaskPane",
+              "Url": "examples/taskpane/subscriberapi.html"
+            },
+            "ImageClass": null,
+            "ImageUrl": null,
+            "Label": "Subscriber API Example",
+            "Location": null,
+            "Name": "SubscriberExample",
+            "StatusText": null,
+            "Tooltip": null,
+            "Type": "InvokeURL"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/actions/__snapshots__/init-dispatchable.spec.ts.snap
+++ b/test/actions/__snapshots__/init-dispatchable.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, dispatches initAppFromDocument, and produces expected redux baseline state 1`] = `
+exports[`actions/init dispatchable integration > produces the same redux golden-master state for legacy(de-arrayified) and clean appdefs 1`] = `
 {
   "config": {
     "activeMapName": "Sheboygan",
@@ -69,7 +69,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
     },
   },
   "initError": {
-    "error": undefined,
     "includeStack": true,
     "options": {},
     "warnings": [],
@@ -77,9 +76,7 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
   "lastaction": {},
   "mapState": {
     "Melbourne": {
-      "clientSelection": undefined,
       "coordinateFormat": "Easting: {x} {units}, Northing: {y} {units}",
-      "currentView": undefined,
       "externalBaseLayers": [
         {
           "kind": "Stamen",
@@ -96,30 +93,21 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           "options": {},
         },
       ],
-      "generic": undefined,
       "history": [],
       "historyIndex": -1,
       "initialExternalLayers": [],
-      "initialView": undefined,
-      "layers": undefined,
       "mapguide": {
-        "activeSelectedFeature": undefined,
         "expandedGroups": {},
         "hideGroups": [],
         "hideLayers": [],
         "isArbitraryCs": false,
         "layerTransparency": {},
-        "runtimeMap": undefined,
         "selectableLayers": {},
-        "selectionSet": undefined,
         "showGroups": [],
         "showLayers": [],
       },
     },
     "Redding": {
-      "clientSelection": undefined,
-      "coordinateFormat": undefined,
-      "currentView": undefined,
       "externalBaseLayers": [
         {
           "kind": "Stamen",
@@ -136,28 +124,21 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           "options": {},
         },
       ],
-      "generic": undefined,
       "history": [],
       "historyIndex": -1,
       "initialExternalLayers": [],
-      "initialView": undefined,
-      "layers": undefined,
       "mapguide": {
-        "activeSelectedFeature": undefined,
         "expandedGroups": {},
         "hideGroups": [],
         "hideLayers": [],
         "isArbitraryCs": false,
         "layerTransparency": {},
-        "runtimeMap": undefined,
         "selectableLayers": {},
-        "selectionSet": undefined,
         "showGroups": [],
         "showLayers": [],
       },
     },
     "Sheboygan": {
-      "clientSelection": undefined,
       "coordinateFormat": "Lng: {x} {units}, Lat: {y} {units}",
       "currentView": {
         "scale": 70000,
@@ -165,14 +146,10 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
         "y": 43.74,
       },
       "externalBaseLayers": [],
-      "generic": undefined,
       "history": [],
       "historyIndex": -1,
       "initialExternalLayers": [],
-      "initialView": undefined,
-      "layers": undefined,
       "mapguide": {
-        "activeSelectedFeature": undefined,
         "expandedGroups": {},
         "hideGroups": [
           "G2",
@@ -260,7 +237,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           "SiteVersion": "4.0.0.0",
         },
         "selectableLayers": {},
-        "selectionSet": undefined,
         "showGroups": [
           "G1",
         ],
@@ -271,9 +247,7 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
     },
   },
   "modal": {},
-  "mouse": {
-    "coords": undefined,
-  },
+  "mouse": {},
   "taskpane": {
     "initialUrl": "http://localhost:3000/server/TaskPane.html?MAPNAME=Sheboygan&SESSION=SESSION-BASELINE&LOCALE=en",
     "lastUrlPushed": false,
@@ -299,7 +273,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
             "command": "RefreshMap",
             "icon": "images/icons.png",
             "label": "Refresh",
-            "parameters": null,
             "spriteClass": "view-refresh",
             "tooltip": "Click to redraw the map",
           },
@@ -310,7 +283,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
             "command": "Pan",
             "icon": "images/icons.png",
             "label": "Pan",
-            "parameters": null,
             "spriteClass": "pan",
             "tooltip": "Click and drag to pan the map",
           },
@@ -354,10 +326,7 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           },
           {
             "children": [],
-            "icon": null,
             "label": "Zoom",
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "isSeparator": true,
@@ -378,16 +347,12 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
             "command": "ClearSelection",
             "icon": "images/icons.png",
             "label": "Clear Selection",
-            "parameters": null,
             "spriteClass": "select-clear",
             "tooltip": "Click to clear the current selection",
           },
           {
             "children": [],
-            "icon": null,
             "label": "Select More",
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "isSeparator": true,
@@ -575,16 +540,12 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           },
           {
             "command": "AddExternalLayers",
-            "icon": null,
             "label": "Manage External Layers",
             "parameters": {
-              "AdditionalParameter": null,
               "DisableIfSelectionEmpty": "false",
               "Target": "TaskPane",
               "Url": "component://AddManageLayers",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "CoordinateTracker",
@@ -602,33 +563,25 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           },
         ],
       },
-      "Tools_4": {
+      "Tools_<id>": {
         "children": [
           {
             "command": "AddExternalLayers",
-            "icon": null,
             "label": "Manage External Layers",
             "parameters": {
-              "AdditionalParameter": null,
               "DisableIfSelectionEmpty": "false",
               "Target": "TaskPane",
               "Url": "component://AddManageLayers",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "ShareLink",
-            "icon": null,
             "label": "Share Link to View",
             "parameters": {
-              "AdditionalParameter": null,
               "DisableIfSelectionEmpty": "false",
               "Target": "InvokeUrlWindow",
               "Url": "component://ShareLinkToView",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "Geolocation",
@@ -658,90 +611,66 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           },
         ],
       },
-      "View_2": {
+      "View_<id>": {
         "children": [
           {
             "command": "showOverview",
-            "icon": null,
             "label": "Show Overview",
             "parameters": {
               "Script": "showOverviewMap()",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "showTaskPane",
-            "icon": null,
             "label": "Show Task Pane",
             "parameters": {
               "Script": "showTaskPane()",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "showLegend",
-            "icon": null,
             "label": "Show Legend",
             "parameters": {
               "Script": "showLegend()",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "showSelectionPanel",
-            "icon": null,
             "label": "Show Selection Panel",
             "parameters": {
               "Script": "showSelectionPanel()",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
         ],
       },
-      "Viewer API_3": {
+      "Viewer API_<id>": {
         "children": [
           {
             "command": "ViewerApiExample",
-            "icon": null,
             "label": "Viewer API Example",
             "parameters": {
-              "AdditionalParameter": null,
               "DisableIfSelectionEmpty": "false",
               "Target": "TaskPane",
               "Url": "examples/taskpane/viewerapi.html",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "DrawingExample",
-            "icon": null,
             "label": "Drawing Example",
             "parameters": {
-              "AdditionalParameter": null,
               "DisableIfSelectionEmpty": "false",
               "Target": "TaskPane",
               "Url": "examples/taskpane/drawing.html",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
             "command": "SubscriberExample",
-            "icon": null,
             "label": "Subscriber API Example",
             "parameters": {
-              "AdditionalParameter": null,
               "DisableIfSelectionEmpty": "false",
               "Target": "TaskPane",
               "Url": "examples/taskpane/subscriberapi.html",
             },
-            "spriteClass": null,
-            "tooltip": null,
           },
         ],
       },
@@ -751,7 +680,7 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
         "items": [
           {
             "componentName": "MapMenu",
-            "flyoutId": "MapMenu_0",
+            "flyoutId": "MapMenu_<id>",
             "icon": "images/icons.png",
             "label": "Maps",
             "parameters": {},
@@ -760,33 +689,23 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           },
           {
             "componentName": "BaseMapSwitcher",
-            "flyoutId": "BaseMapSwitcher_1",
+            "flyoutId": "BaseMapSwitcher_<id>",
             "icon": "images/icons.png",
             "label": "External Providers",
-            "parameters": null,
             "spriteClass": "options",
             "tooltip": "Click to change the basemap",
           },
           {
-            "flyoutId": "View_2",
-            "icon": null,
+            "flyoutId": "View_<id>",
             "label": "View",
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
-            "flyoutId": "Viewer API_3",
-            "icon": null,
+            "flyoutId": "Viewer API_<id>",
             "label": "Viewer API",
-            "spriteClass": null,
-            "tooltip": null,
           },
           {
-            "flyoutId": "Tools_4",
-            "icon": null,
+            "flyoutId": "Tools_<id>",
             "label": "Tools",
-            "spriteClass": null,
-            "tooltip": null,
           },
         ],
       },
@@ -840,7 +759,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
               "ShowSubTitle": "true",
               "Target": "TaskPane",
             },
-            "spriteClass": null,
             "tooltip": "Click to create a plot quickly",
           },
           {
@@ -850,7 +768,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
             "command": "RefreshMap",
             "icon": "images/icons.png",
             "label": "Refresh",
-            "parameters": null,
             "spriteClass": "view-refresh",
             "tooltip": "Click to redraw the map",
           },
@@ -907,7 +824,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
             "command": "ClearSelection",
             "icon": "images/icons.png",
             "label": "Clear Selection",
-            "parameters": null,
             "spriteClass": "select-clear",
             "tooltip": "Click to clear the current selection",
           },
@@ -1034,7 +950,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
             "command": "Pan",
             "icon": "images/icons.png",
             "label": "Pan",
-            "parameters": null,
             "spriteClass": "pan",
             "tooltip": "Click and drag to pan the map",
           },
@@ -1118,7 +1033,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "Select",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "QueryActiveLayer": "false",
               "SelectionType": "INTERSECTS",
@@ -1133,15 +1047,12 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "Pan",
             "icon": "images/icons.png",
-            "label": null,
-            "parameters": null,
             "spriteClass": "pan",
             "tooltip": "Click and drag to pan the map",
           },
           {
             "command": "Zoom",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "Direction": "in",
               "Factor": "2",
@@ -1153,7 +1064,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "ZoomIn",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "Factor": "2",
             },
@@ -1163,7 +1073,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "ZoomOut",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "Factor": "0.5",
             },
@@ -1173,7 +1082,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "ZoomExtents",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "ViewType": "initial",
             },
@@ -1183,7 +1091,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "ZoomToSelection",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "MaximumZoomDimension": "-1",
               "ZoomFactor": "2",
@@ -1194,7 +1101,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "PreviousView",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "Direction": "previous",
             },
@@ -1204,7 +1110,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
           {
             "command": "NextView",
             "icon": "images/icons.png",
-            "label": null,
             "parameters": {
               "Direction": "next",
             },
@@ -1218,7 +1123,6 @@ exports[`actions/init dispatchable integration > de-arrayifies legacy appdef, di
   "viewer": {
     "busyCount": 0,
     "featureTooltipsEnabled": false,
-    "size": undefined,
     "tool": 2,
   },
 }

--- a/test/actions/init-dispatchable.spec.ts
+++ b/test/actions/init-dispatchable.spec.ts
@@ -5,6 +5,7 @@ import { initAppFromDocument } from "../../src/actions/init";
 import { AsyncLazy } from "../../src/api/lazy";
 import { deArrayify, isAppDef } from "../../src/api/builders/deArrayify";
 import legacyAppDef from "../../test-data/init_appdef_legacy";
+import cleanAppDef from "../../test-data/init_appdef_clean";
 
 const clientMock = vi.hoisted(() => ({
     createSession: vi.fn(),
@@ -114,6 +115,91 @@ function makeRuntimeMap(name: string, sessionId: string) {
     } as any;
 }
 
+function normalizePreDeArrayifiedAppDef(appDef: any) {
+    const clone = JSON.parse(JSON.stringify(appDef));
+    const normalizeItems = (items: any[]) => {
+        for (const item of items || []) {
+            if (item.Function === "Flyout") {
+                if (!Array.isArray(item.Item)) {
+                    item.Item = [];
+                }
+                normalizeItems(item.Item);
+            }
+        }
+    };
+    for (const ws of clone.WidgetSet || []) {
+        if (ws.MapWidget && ws.MapWidget["@xsi:type"] && !ws.MapWidget.WidgetType) {
+            ws.MapWidget.WidgetType = ws.MapWidget["@xsi:type"];
+        }
+        for (const widget of ws.Widget || []) {
+            if (widget["@xsi:type"] && !widget.WidgetType) {
+                widget.WidgetType = widget["@xsi:type"];
+            }
+        }
+        for (const cont of ws.Container || []) {
+            if (!Array.isArray(cont.Item)) {
+                cont.Item = [];
+            }
+            normalizeItems(cont.Item);
+        }
+    }
+    return clone;
+}
+
+function canonicalizeStateForComparison(input: any): any {
+    if (Array.isArray(input)) {
+        return input.map(canonicalizeStateForComparison);
+    }
+    if (input && typeof input === "object") {
+        const result: any = {};
+        for (const key of Object.keys(input)) {
+            let value = canonicalizeStateForComparison(input[key]);
+            if (key === "flyoutId" && typeof value === "string") {
+                value = value.replace(/(_\d+)+$/, "_<id>");
+            }
+            if (value === null || typeof value === "undefined") {
+                continue;
+            }
+            const normalizedKey = key.replace(/(_\d+)+$/, "_<id>");
+            result[normalizedKey] = value;
+        }
+        return result;
+    }
+    return input;
+}
+
+async function dispatchInitAndGetState(document: any) {
+    const session = new AsyncLazy<string>(async () => "SESSION-BASELINE");
+
+    const store = configureStore({
+        config: {
+            ...CONFIG_INITIAL_STATE,
+            agentUri: "http://example.com/mapagent/mapagent.fcgi",
+            agentKind: "mapagent",
+        },
+    }) as any;
+
+    await store.dispatch(initAppFromDocument({
+        document,
+        session,
+        sessionWasReused: false,
+    }, {
+        locale: "en",
+        initialView: { x: -87.72, y: 43.74, scale: 70000 },
+        initialActiveMap: "Sheboygan",
+        initialShowLayers: ["Parcels Layer"],
+        initialHideLayers: ["Roads Layer"],
+        initialShowGroups: ["Infrastructure"],
+        initialHideGroups: ["Parcels"],
+        featureTooltipsEnabled: false,
+        appSettings: {
+            baseline: "legacy-appdef",
+        },
+    }) as any);
+
+    return store.getState();
+}
+
 describe("actions/init dispatchable integration", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -126,48 +212,29 @@ describe("actions/init dispatchable integration", () => {
         });
     });
 
-    it("de-arrayifies legacy appdef, dispatches initAppFromDocument, and produces expected redux baseline state", async () => {
+    it("produces the same redux golden-master state for legacy(de-arrayified) and clean appdefs", async () => {
         const normalized = deArrayify(legacyAppDef as any);
         expect(isAppDef(normalized)).toBe(true);
         if (!isAppDef(normalized)) {
             throw new Error("Expected legacy payload to de-arrayify to an ApplicationDefinition");
         }
+        const cleanDocument = normalizePreDeArrayifiedAppDef((cleanAppDef as any).ApplicationDefinition);
+        expect(isAppDef(cleanDocument as any)).toBe(true);
+        if (!isAppDef(cleanDocument as any)) {
+            throw new Error("Expected clean payload to be an ApplicationDefinition");
+        }
 
-        const appDef = normalized;
-        const session = new AsyncLazy<string>(async () => "SESSION-BASELINE");
+        const legacyState = await dispatchInitAndGetState(normalized);
+        const legacyCanonical = canonicalizeStateForComparison(legacyState);
+        expect(legacyCanonical).toMatchSnapshot();
 
-        const store = configureStore({
-            config: {
-                ...CONFIG_INITIAL_STATE,
-                agentUri: "http://example.com/mapagent/mapagent.fcgi",
-                agentKind: "mapagent",
-            },
-        }) as any;
-
-        await store.dispatch(initAppFromDocument({
-            document: appDef,
-            session,
-            sessionWasReused: false,
-        }, {
-            locale: "en",
-            initialView: { x: -87.72, y: 43.74, scale: 70000 },
-            initialActiveMap: "Sheboygan",
-            initialShowLayers: ["Parcels Layer"],
-            initialHideLayers: ["Roads Layer"],
-            initialShowGroups: ["Infrastructure"],
-            initialHideGroups: ["Parcels"],
-            featureTooltipsEnabled: false,
-            appSettings: {
-                baseline: "legacy-appdef",
-            },
-        }) as any);
-
-        const state = store.getState();
-        expect(state).toMatchSnapshot();
+        const cleanState = await dispatchInitAndGetState(cleanDocument);
+        const cleanCanonical = canonicalizeStateForComparison(cleanState);
+        expect(cleanCanonical).toEqual(legacyCanonical);
 
         // runtime map bootstrap behavior
-        expect(clientMock.getSiteVersion).toHaveBeenCalledTimes(1);
-        expect(clientMock.createRuntimeMap_v4).toHaveBeenCalledTimes(1);
+        expect(clientMock.getSiteVersion).toHaveBeenCalledTimes(2);
+        expect(clientMock.createRuntimeMap_v4).toHaveBeenCalledTimes(2);
         expect(clientMock.createRuntimeMap).not.toHaveBeenCalled();
     });
 });

--- a/test/api/builders/de-arrayify.spec.ts
+++ b/test/api/builders/de-arrayify.spec.ts
@@ -18,6 +18,13 @@ import { convertFlexLayoutUIItems, convertWebLayoutUIItems, parseCommandsInWebLa
 import { isRuntimeMap } from "../../../src/utils/type-guards";
 
 describe("de-arrayify", () => {
+    it("convertFlexLayoutUIItems handles nullish items", () => {
+        const result1 = convertFlexLayoutUIItems(false, undefined as any, {}, "en");
+        const result2 = convertFlexLayoutUIItems(false, null as any, {}, "en");
+        expect(result1).toEqual([]);
+        expect(result2).toEqual([]);
+    });
+
     it("Fixes #631", () => {
         const appDef = deArrayify(TEST_DATA);
         const valid = isAppDef(appDef);

--- a/test/api/builders/mapagent.spec.ts
+++ b/test/api/builders/mapagent.spec.ts
@@ -5,6 +5,7 @@ describe("api/builders/mapagent getResource", () => {
    beforeEach(() => {
       vi.restoreAllMocks();
       vi.clearAllMocks();
+      (MapAgentRequestBuilder as any).siteVersionCache.clear();
    });
 
    it("uses GETRESOURCECONTENT VERSION=4.0.0 CLEAN=1 for ApplicationDefinition on 4.0+ and skips de-arrayification", async () => {
@@ -151,5 +152,94 @@ describe("api/builders/mapagent getResource", () => {
       expect(wlUrl).toContain("OPERATION=GETRESOURCECONTENT");
       expect(wlUrl).toContain("VERSION=1.0.0");
       expect(wlUrl).not.toContain("CLEAN=1");
+   });
+
+   it("caches and reuses GETSITEVERSION responses per agent uri", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         .mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ SiteVersion: { Version: ["4.0.0.0"] } }),
+         } as Response);
+
+      const builder1 = new MapAgentRequestBuilder("http://example.test/mapagent/cache.fcgi");
+      const builder2 = new MapAgentRequestBuilder("http://example.test/mapagent/cache.fcgi");
+
+      await expect(builder1.getSiteVersion()).resolves.toEqual({ Version: "4.0.0.0" });
+      await expect(builder2.getSiteVersion()).resolves.toEqual({ Version: "4.0.0.0" });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const siteVersionUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(siteVersionUrl).toContain("OPERATION=GETSITEVERSION");
+   });
+
+   it("uses clean v4 runtime map creation and skips de-arrayification", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+               RuntimeMap: {
+                  Name: "Map1",
+                  SessionId: "S1",
+                  SiteVersion: "4.0.0.0",
+                  BackgroundColor: "FF000000",
+                  DisplayDpi: 96,
+                  CoordinateSystem: { Wkt: "", MentorCode: "", EpsgCode: "4326", MetersPerUnit: 1 },
+                  Extents: {
+                     LowerLeftCoordinate: { X: 0, Y: 0 },
+                     UpperRightCoordinate: { X: 100, Y: 100 },
+                  },
+                  Group: [],
+                  Layer: [],
+               },
+            }),
+         } as Response);
+
+      const builder = new MapAgentRequestBuilder("http://example.test/mapagent/runtime-create.fcgi");
+      const map = await builder.createRuntimeMap_v4({ mapDefinition: "Library://Samples/Sheboygan.MapDefinition", targetMapName: "Map1" } as any);
+
+      expect(map.Name).toBe("Map1");
+      expect(map.Group).toEqual([]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain("OPERATION=CREATERUNTIMEMAP");
+      expect(url).toContain("VERSION=4.0.0");
+      expect(url).toContain("CLEAN=1");
+   });
+
+   it("uses clean v4 runtime map description and skips de-arrayification", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+               RuntimeMap: {
+                  Name: "Map2",
+                  SessionId: "S2",
+                  SiteVersion: "4.0.0.0",
+                  BackgroundColor: "FF000000",
+                  DisplayDpi: 96,
+                  CoordinateSystem: { Wkt: "", MentorCode: "", EpsgCode: "4326", MetersPerUnit: 1 },
+                  Extents: {
+                     LowerLeftCoordinate: { X: 0, Y: 0 },
+                     UpperRightCoordinate: { X: 100, Y: 100 },
+                  },
+                  Group: [],
+                  Layer: [],
+               },
+            }),
+         } as Response);
+
+      const builder = new MapAgentRequestBuilder("http://example.test/mapagent/runtime-describe.fcgi");
+      const map = await builder.describeRuntimeMap_v4({ mapname: "Map2", requestedFeatures: 7 } as any);
+
+      expect(map.Name).toBe("Map2");
+      expect(map.Layer).toEqual([]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain("OPERATION=DESCRIBERUNTIMEMAP");
+      expect(url).toContain("VERSION=4.0.0");
+      expect(url).toContain("CLEAN=1");
    });
 });

--- a/test/api/builders/mapagent.spec.ts
+++ b/test/api/builders/mapagent.spec.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MapAgentRequestBuilder } from "../../../src/api/builders/mapagent";
+
+describe("api/builders/mapagent getResource", () => {
+   beforeEach(() => {
+      vi.restoreAllMocks();
+      vi.clearAllMocks();
+   });
+
+   it("uses GETRESOURCECONTENT VERSION=4.0.0 CLEAN=1 for ApplicationDefinition on 4.0+ and skips de-arrayification", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         // GETSITEVERSION (arrayified)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ SiteVersion: { Version: ["4.0.0.0"] } }),
+         } as Response)
+         // GETRESOURCECONTENT (clean, already de-arrayified)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+               ApplicationDefinition: {
+                  Title: "Clean Title",
+                  TemplateUrl: "fusion/templates/mapguide/slate/index.html",
+                  MapSet: { MapGroup: [] },
+                  WidgetSet: [],
+                  Extension: {},
+               },
+            }),
+         } as Response);
+
+      const builder = new MapAgentRequestBuilder("http://example.test/mapagent/mapagent.fcgi");
+      const appDef = await builder.getResource<any>("Library://Samples/App.ApplicationDefinition", { SESSION: "S1" });
+
+      expect(appDef.Title).toBe("Clean Title");
+      expect(appDef.MapSet).toEqual({ MapGroup: [] });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      const siteVersionUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(siteVersionUrl).toContain("OPERATION=GETSITEVERSION");
+
+      const appDefUrl = fetchSpy.mock.calls[1][0] as string;
+      expect(appDefUrl).toContain("OPERATION=GETRESOURCECONTENT");
+      expect(appDefUrl).toContain("RESOURCEID=Library://Samples/App.ApplicationDefinition");
+      expect(appDefUrl).toContain("SESSION=S1");
+      expect(appDefUrl).toContain("VERSION=4.0.0");
+      expect(appDefUrl).toContain("CLEAN=1");
+   });
+
+   it("treats ApplicationDefinition resource id case-insensitively for CLEAN=1 path", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ SiteVersion: { Version: ["4.0.0.10202"] } }),
+         } as Response)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+               ApplicationDefinition: {
+                  Title: "Clean Lowercase",
+                  TemplateUrl: "fusion/templates/mapguide/slate/index.html",
+                  MapSet: { MapGroup: [] },
+                  WidgetSet: [],
+                  Extension: {},
+               },
+            }),
+         } as Response);
+
+      const builder = new MapAgentRequestBuilder("http://example.test/mapagent/mapagent.fcgi");
+      const appDef = await builder.getResource<any>("Library://Samples/App.applicationdefinition", { SESSION: "S1" });
+
+      expect(appDef.Title).toBe("Clean Lowercase");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const appDefUrl = fetchSpy.mock.calls[1][0] as string;
+      expect(appDefUrl).toContain("VERSION=4.0.0");
+      expect(appDefUrl).toContain("CLEAN=1");
+   });
+
+   it("uses legacy GETRESOURCECONTENT parameters for ApplicationDefinition on pre-4.0 servers", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         // GETSITEVERSION (arrayified)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ SiteVersion: { Version: ["3.1.0.0"] } }),
+         } as Response)
+         // GETRESOURCECONTENT (legacy arrayified appdef)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+               ApplicationDefinition: {
+                  Title: ["Legacy Title"],
+                  TemplateUrl: ["fusion/templates/mapguide/slate/index.html"],
+                  MapSet: [{ MapGroup: [] }],
+                  WidgetSet: [],
+                  Extension: null,
+               },
+            }),
+         } as Response);
+
+      const builder = new MapAgentRequestBuilder("http://example.test/mapagent/mapagent.fcgi");
+      const appDef = await builder.getResource<any>("Library://Samples/App.ApplicationDefinition", { SESSION: "S1" });
+
+      expect(appDef.Title).toBe("Legacy Title");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      const appDefUrl = fetchSpy.mock.calls[1][0] as string;
+      expect(appDefUrl).toContain("OPERATION=GETRESOURCECONTENT");
+      expect(appDefUrl).toContain("RESOURCEID=Library://Samples/App.ApplicationDefinition");
+      expect(appDefUrl).toContain("SESSION=S1");
+      expect(appDefUrl).toContain("VERSION=1.0.0");
+      expect(appDefUrl).not.toContain("CLEAN=1");
+   });
+
+   it("does not probe site version for non-ApplicationDefinition resources", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch" as any)
+         .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+               WebLayout: {
+                  Title: ["WL"],
+                  Map: [{ ResourceId: ["Library://Samples/Map.MapDefinition"] }],
+                  EnablePingServer: ["false"],
+                  SelectionColor: ["0x0000FFAA"],
+                  PointSelectionBuffer: ["2"],
+                  MapImageFormat: ["PNG"],
+                  SelectionImageFormat: ["PNG8"],
+                  StartupScript: [""],
+                  ToolBar: [{ Visible: ["true"], Button: [] }],
+                  InformationPane: [{ Visible: ["true"], Width: ["300"], LegendVisible: ["true"], PropertiesVisible: ["true"] }],
+                  ContextMenu: [{ Visible: ["true"], MenuItem: [] }],
+                  TaskPane: [{ Visible: ["true"], InitialTask: ["server/TaskPane.html"], Width: ["300"], TaskBar: [{ Visible: ["true"], Home: [{ Name: ["Home"], Tooltip: [""], Description: [""], ImageURL: [""], DisabledImageURL: [""] }], Forward: [{ Name: ["Fwd"], Tooltip: [""], Description: [""], ImageURL: [""], DisabledImageURL: [""] }], Back: [{ Name: ["Back"], Tooltip: [""], Description: [""], ImageURL: [""], DisabledImageURL: [""] }], Tasks: [{ Name: ["Tasks"], Tooltip: [""], Description: [""], ImageURL: [""], DisabledImageURL: [""] }], MenuButton: [] }] }],
+                  StatusBar: [{ Visible: ["true"] }],
+                  ZoomControl: [{ Visible: ["true"] }],
+                  CommandSet: [{ Command: [] }],
+               },
+            }),
+         } as Response);
+
+      const builder = new MapAgentRequestBuilder("http://example.test/mapagent/mapagent.fcgi");
+      const wl = await builder.getResource<any>("Library://Samples/App.WebLayout", { SESSION: "S1" });
+
+      expect(wl.Title).toBe("WL");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const wlUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(wlUrl).toContain("OPERATION=GETRESOURCECONTENT");
+      expect(wlUrl).toContain("VERSION=1.0.0");
+      expect(wlUrl).not.toContain("CLEAN=1");
+   });
+});


### PR DESCRIPTION
This pull request introduces several important improvements to the handling of MapAgent API responses and UI widget processing, as well as updates to related test snapshots. The changes focus on supporting "clean" resource content for newer site versions, improving type detection for UI widgets, and ensuring better compatibility and consistency in the application's Redux state and UI conversion logic.

**MapAgent API Enhancements:**
- Added logic to detect site version and use the "clean" resource content API for `ApplicationDefinition` resources when supported (MapGuide 4.0+), which simplifies resource parsing and improves future compatibility. [[1]](diffhunk://#diff-381364b79b0dd231f8cd3ddb646a89b93b1401b80d3e3fe463ac297bb62f79c0R8) [[2]](diffhunk://#diff-381364b79b0dd231f8cd3ddb646a89b93b1401b80d3e3fe463ac297bb62f79c0R43-R94) [[3]](diffhunk://#diff-381364b79b0dd231f8cd3ddb646a89b93b1401b80d3e3fe463ac297bb62f79c0L144-R224)
- Implemented a cache for site version lookups to avoid redundant network requests and improve performance.
- Refactored `createRuntimeMap_v4` and `describeRuntimeMap_v4` to use the clean API and extract the relevant JSON payload, ensuring more reliable and predictable data structures. [[1]](diffhunk://#diff-381364b79b0dd231f8cd3ddb646a89b93b1401b80d3e3fe463ac297bb62f79c0L167-R237) [[2]](diffhunk://#diff-381364b79b0dd231f8cd3ddb646a89b93b1401b80d3e3fe463ac297bb62f79c0L189-R260)

**UI Widget Handling Improvements:**
- Enhanced the `isUIWidget` type guard to recognize widgets using either the `WidgetType` property or the `@xsi:type` property, increasing compatibility with various widget definitions.
- Made widget conversion logic more robust by handling cases where the items array may be undefined, preventing runtime errors.

**Test and Redux State Updates:**
- Updated Redux baseline state and snapshot tests to reflect the new clean resource content handling, removal of unnecessary `undefined` properties, and normalization of flyout and toolbar IDs for consistency between legacy and clean app definitions. [[1]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL3-R3) [[2]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL72-L82) [[3]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL99-L122) [[4]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL139-L175) [[5]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL263) [[6]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL274-R250) [[7]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL302) [[8]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL313) [[9]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL357-L360) [[10]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL381-L390) [[11]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL578-L587) [[12]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL605-L631) [[13]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL661-L744) [[14]](diffhunk://#diff-bd45f61ae75abd3c424f7edbf46c6d492ec853c23dce3e6f31b8b6b7e96cf7deL754-R683)

These changes improve maintainability, compatibility with future MapGuide versions, and the reliability of UI and state initialization logic.

Fixes #217 